### PR TITLE
Update link to external site for daniel dickinson

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hugo DFD Demo Site Theme
 
-A theme for [Hugo](https://gohugo.io) module demo sites by [Daniel F. Dickinson](https://www.danielfdickinson.ca).
+A theme for [Hugo](https://gohugo.io) module demo sites by [Daniel F. Dickinson](https://www.wildtechgarden.ca/).
 
 ## Netlify Status
 


### PR DESCRIPTION
We do do this so that exernal link checks succeed when README is
imported as a page on wildtechgarden.ca

Signed-off-by: Daniel F. Dickinson <20735818+danielfdickinson@users.noreply.github.com>